### PR TITLE
Actualizada la documentacion con biblioteca aserciones y marco de tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,52 @@ No dependencies to install or update
 Se puede encontrar más información respectiva a la resolución de la tarea
 en [documentacion/hito_2/gestor_tareas.md](https://github.com/mcarmona99/CineTickets/blob/master/documentacion/hito_2/gestor_tareas.md)
 .
+
+#### [#20 - Biblioteca de aserciones](https://github.com/mcarmona99/CineTickets/issues/20) y [#21 - Marco de pruebas](https://github.com/mcarmona99/CineTickets/issues/21)
+
+El framework o marco de tests elegido es [pytest](https://pypi.org/project/pytest/). Este marco de testing permite escribir test pequeños pero que a su vez pueden aumentar en complejidad si decidimos escalar a otros proyectos o librerías.
+
+Ejemplo de uso de pytest:
+
+```python
+# content of test_sample.py
+def inc(x):
+    return x + 1
+
+
+def test_answer():
+    assert inc(3) == 5
+```
+
+```bash
+$ pytest
+============================= test session starts =============================
+collected 1 items
+
+test_sample.py F
+
+================================== FAILURES ===================================
+_________________________________ test_answer _________________________________
+
+    def test_answer():
+>       assert inc(3) == 5
+E       assert 4 == 5
+E        +  where 4 = inc(3)
+
+test_sample.py:5: AssertionError
+========================== 1 failed in 0.04 seconds ===========================
+```
+
+Como biblioteca de aserciones, se puede usar la propia herramienta pytest, que ya contiene features o funciones tales como pytest.raises, assert_called_with y otras funciones para mock, etc.
+Se usará pytest, pero también haremos uso de assertpy, que es una biblioteca de aserciones con funciones definidas con una sintaxis de "más alto nivel" y que por tanto hace que el desarrollo de tests sea más fácil.
+
+Referencias de la biblioteca assertpy: [pypi](https://pypi.org/project/assertpy/) y [GitHub](https://github.com/assertpy/assertpy)
+
+```python
+from assertpy import assert_that
+
+def test_something():
+    assert_that(1 + 2).is_equal_to(3)
+    assert_that('foobar').is_length(6).starts_with('foo').ends_with('bar')
+    assert_that(['a', 'b', 'c']).contains('a').does_not_contain('x')
+```

--- a/documentacion/hito_2/biblioteca_aserciones_marco_tests.md
+++ b/documentacion/hito_2/biblioteca_aserciones_marco_tests.md
@@ -1,0 +1,52 @@
+# CineTickets
+
+## Marco de tests
+
+El framework o marco de tests elegido es [pytest](https://pypi.org/project/pytest/). Este marco de testing permite escribir test pequeños pero que a su vez pueden aumentar en complejidad si decidimos escalar a otros proyectos o librerías.
+
+Ejemplo de uso de pytest:
+
+```python
+# content of test_sample.py
+def inc(x):
+    return x + 1
+
+
+def test_answer():
+    assert inc(3) == 5
+```
+
+```bash
+$ pytest
+============================= test session starts =============================
+collected 1 items
+
+test_sample.py F
+
+================================== FAILURES ===================================
+_________________________________ test_answer _________________________________
+
+    def test_answer():
+>       assert inc(3) == 5
+E       assert 4 == 5
+E        +  where 4 = inc(3)
+
+test_sample.py:5: AssertionError
+========================== 1 failed in 0.04 seconds ===========================
+```
+
+## Biblioteca de aserciones
+
+Como biblioteca de aserciones, se puede usar la propia herramienta pytest, que ya contiene features o funciones tales como pytest.raises, assert_called_with y otras funciones para mock, etc.
+Se usará pytest, pero también haremos uso de assertpy, que es una biblioteca de aserciones con funciones definidas con una sintaxis de "más alto nivel" y que por tanto hace que el desarrollo de tests sea más fácil.
+
+Referencias de la biblioteca assertpy: [pypi](https://pypi.org/project/assertpy/) y [GitHub](https://github.com/assertpy/assertpy)
+
+```python
+from assertpy import assert_that
+
+def test_something():
+    assert_that(1 + 2).is_equal_to(3)
+    assert_that('foobar').is_length(6).starts_with('foo').ends_with('bar')
+    assert_that(['a', 'b', 'c']).contains('a').does_not_contain('x')
+```


### PR DESCRIPTION
## Descripción

Tanto la issue 20 como la 21 se resuelven con este pull request (close #20, close #21).

En ambas issues se pide, respectivamente, especificar una biblioteca de aserciones y un framework o marco de tests.

### Marco de tests

El framework o marco de tests elegido es [pytest](https://pypi.org/project/pytest/). Este marco de testing permite escribir test pequeños pero que a su vez pueden aumentar en complejidad si decidimos escalar a otros proyectos o librerías.

Ejemplo de uso de pytest:

```python
# content of test_sample.py
def inc(x):
    return x + 1


def test_answer():
    assert inc(3) == 5
```

```bash
$ pytest
============================= test session starts =============================
collected 1 items

test_sample.py F

================================== FAILURES ===================================
_________________________________ test_answer _________________________________

    def test_answer():
>       assert inc(3) == 5
E       assert 4 == 5
E        +  where 4 = inc(3)

test_sample.py:5: AssertionError
========================== 1 failed in 0.04 seconds ===========================
```

### Biblioteca de aserciones

Como biblioteca de aserciones, se puede usar la propia herramienta pytest, que ya contiene features o funciones tales como pytest.raises, assert_called_with y otras funciones para mock, etc.
Se usará pytest, pero también haremos uso de assertpy, que es una biblioteca de aserciones con funciones definidas con una sintaxis de "más alto nivel" y que por tanto hace que el desarrollo de tests sea más fácil.

Referencias de la biblioteca assertpy: [pypi](https://pypi.org/project/assertpy/) y [GitHub](https://github.com/assertpy/assertpy)

```python
from assertpy import assert_that

def test_something():
    assert_that(1 + 2).is_equal_to(3)
    assert_that('foobar').is_length(6).starts_with('foo').ends_with('bar')
    assert_that(['a', 'b', 'c']).contains('a').does_not_contain('x')
```