### PR TITLE
Añade alternativas documentadas a la sección de gestores de tareas

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,28 +62,133 @@ ventajas y desventajas de algunas de las opciones que tenemos para gestores de t
 Python. [Esta lista](https://www.libhunt.com/t/task-runner) ha sido de utilidad. En ella encontramos un top de task
 runners para proyecto open-source, que puede ser filtrado por lenguaje.
 
-Si vemos el primer task runner de la lista, `celery`, vemos que es un gestor orientado a tareas distribuidas, lo cuál no
-va a ser interesante en nuestro caso ya que queremos un gestor que nos ejecute tareas de manera local o mejor dicho, en
-un sólo host o máquina.
+Analizo los siguientes tasks runner:
 
-Otra posible opción es dramatiq, pero en este caso, este task runner es usado para procesar tareas en background.
-Tampoco es lo que queremos para el proyecto.
+#### pypyr
 
-Finalmente elijo `pypyr`, por la facilidad de uso y experiencia previa con la herramienta.
+Este task runner o gestor de tareas se usa para automatización y funciona con el lenguaje de marcas `yaml`. Como se
+comenta en su [web oficial](https://pypyr.io/), este task runner se usa para cuando los scripts shell se vuelven algo
+complejos. Más sencillo que un Makefile.
+
+Con este gestor, se puede automatizar todo combinando comandos; y sobre todo y algo que lo hace muy versátil es que
+podemos usar scripts escritos en distintos lenguajes de programación en un mismo pipeline.
+
+Ejemplo: archivo `tests.yaml`
+
+```yaml
+# To execute this pipeline, shell something like:
+# pypyr tests
+steps:
+  - name: pypyr.steps.cmd
+    comment: Run the project tests using pytest.
+    in:
+      cmd: pytest
+```
+
+#### taskipy
+
+Usado para tareas de pipeline de desarrollos, como pueden ser test, lint or publish.
+
+Como ventaja, tiene la posibilidad de ser integrado con poetry, de forma que se puede añadir lo siguiente a poetry:
+
+```toml
+[tool.taskipy.tasks]
+test = "python -m unittest tests/test_*.py"
+lint = "pylint tests taskipy"
+```
+
+y también documentar cada task:
+
+```toml
+[tool.taskipy.tasks]
+test = { cmd = "python -m unittest tests/test_*.py", help = "runs all unit tests" }
+lint = { cmd = "pylint tests taskipy", help = "confirms code style using pylint" } 
+```
+
+para después lanzar cada task desde poetry con `poetry run task test`
+
+Como desventaja, depende mucho de poetry, ya que su uso fuera de poetry está poco documentado. Otra desventaja es que
+tasks con muchos commandos se pueden volver complejas, ya que estaríamos incluyéndolas en el `pyproject.toml` de poetry.
+
+Fuertemente inspirado en el task runner de npm: [npm-run-script](https://docs.npmjs.com/cli/v8/commands/npm-run-script)
+
+#### poethepoet
+
+Muy similar a `taskipy`.
+
+En este caso, tenemos completa dependencia de poetry.
+
+```toml
+[tool.poe.tasks]
+  test       = "pytest --cov=poethepoet"                                # simple command based task
+  mksandwich = { script = "my_package.sandwich:build" }                 # python script based task
+  tunnel     = { shell = "ssh -N -L 0.0.0.0:8080:$PROD:8080 $PROD &" }  # shell script based task
+```
+
+En `poethepoet`, tenemos una de las ventajas de pypyr, podemos usar varios lenguajes y en este caso, especificar si es
+lenguaje o apuntar a un script de otro directorio, ejemplo task `mksandwich`.
+
+De nuevo como desventaja, complejidad si tenemos muchos comandos para una misma task.
+
+#### invoke
+
+Provee una API de alto nivel para lanzar comandos de shell.
+
+Las tasks en invoke están escritas en python y agrupadas en forma de funciones en un archivo `tasks.py`, con lo que su
+estructuración es limpia en cuanto a archivos. Se usa el decorador @task para indicar que una función representa una
+tarea para el task runner.
+
+Permite pasar parámetros a cada una de las tareas por medio de flags, lo que lo hace versátil:
+
+```python
+from invoke import task
+
+
+@task
+def clean(c, docs=False, bytecode=False, extra=''):
+    patterns = ['build']
+    if docs:
+        patterns.append('docs/_build')
+    if bytecode:
+        patterns.append('**/*.pyc')
+    if extra:
+        patterns.append(extra)
+    for pattern in patterns:
+        c.run("rm -rf {}".format(pattern))
+```
+
+Uso:
+
+```bash
+$ invoke clean --docs --bytecode build --docs --extra='**/*.pyo'
+$ invoke clean -d -b build --docs -e '**/*.pyo'
+$ invoke clean -db build -de '**/*.pyo'
+```
+
+#### Conclusión
+
+Como conclusión, debato entre usar `pypyr` o `invoke`.
+
+Descarto `taskipy` y `poethepoet` por su alta dependencia de `poetry` y porque al realizar tareas más complejas, se
+pierde la facilidad de uso, ya que tendríamos que incorporar al `pyproject.toml` varias líneas para ejecución de una
+misma tarea, lo que ensuciaría bastante el archivo.
+
+Entre `pypyr` e `invoke`, decido usar `pypyr` por la modularización que propone. En este task runner, a diferencia
+de `invoke`, podemos dividir cada tarea en un archivo distinto, lo que mejora la legibilidad de cada tarea a costa de
+tener comandos y archivos distintos para cada tarea. Además de esto, tenemos la oportunidad de usar más lenguajes, cosa
+que también aporta `invoke` pero con alguna limitación, ya que parte de un script de `python`.
 
 Este task runner o gestor de tareas se usa para automatización y funciona con el lenguaje de marcas yaml. Como se
-comenta en su web oficial, este task runner se usa para cuando los scripts shell se vuelven algo complejos. Más sencillo
-que un Makefile.
+comenta en su web oficial, este task runner se usa para cuando los scripts shell se vuelven algo complejos.
 
 Con este gestor, se puede automatizar todo combinando comandos; y sobre todo y algo que lo hace muy versátil es que
 podemos usar scripts escritos en distintos lenguajes de programación en un mismo pipeline.
 
 Siguiendo la guía encontrada en https://pypyr.io/docs/getting-started/run-your-first-pipeline/, creo
-`my-first-pipeline.yaml` como archivo gestor de tareas base. Este primer pipeline se lanzaría con `poetry`, como se ha
-especificado en la issue anterior:
+`my-first-pipeline.yaml` como archivo gestor de tareas base. Este primer pipeline se lanza de la siguiente forma:
 
 ```shell
-$ poetry run pypyr my-first-pipeline
+$ pypyr my-first-pipeline
 this is step 1
 this is step 2
 ```
@@ -91,7 +196,7 @@ this is step 2
 Este pipeline se ha adaptado para generar el archivo referente a la orden `installdeps` del proyecto:
 
 ```shell
-$ poetry run pypyr installdeps
+$ pypyr installdeps
 Installing dependencies from lock file
 
 No dependencies to install or update

--- a/installdeps.yaml
+++ b/installdeps.yaml
@@ -1,7 +1,5 @@
 # To execute this pipeline, shell something like:
 # pypyr installdeps
-# or, in this case,
-# poetry run pypyr installdeps
 steps:
   - name: pypyr.steps.cmd
     comment: Installs the project dependencies using poetry.

--- a/poetry.lock
+++ b/poetry.lock
@@ -69,11 +69,11 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
-version = "1.10.0"
+version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pyparsing"
@@ -82,21 +82,6 @@ description = "Python parsing module"
 category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
-name = "pypyr"
-version = "4.6.0"
-description = "task-runner for automation pipelines defined in yaml. cli & api."
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-python-dateutil = "*"
-"ruamel.yaml" = "*"
-
-[package.extras]
-dev = ["bumpversion", "codecov", "flake8", "flake8-docstrings", "pytest", "pytest-cov", "setuptools", "twine", "wheel"]
 
 [[package]]
 name = "pytest"
@@ -120,48 +105,6 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-name = "python-dateutil"
-version = "2.8.2"
-description = "Extensions to the standard Python datetime module"
-category = "main"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-
-[package.dependencies]
-six = ">=1.5"
-
-[[package]]
-name = "ruamel.yaml"
-version = "0.17.17"
-description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
-category = "main"
-optional = false
-python-versions = ">=3"
-
-[package.dependencies]
-"ruamel.yaml.clib" = {version = ">=0.1.2", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.10\""}
-
-[package.extras]
-docs = ["ryd"]
-jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
-
-[[package]]
-name = "ruamel.yaml.clib"
-version = "0.2.6"
-description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
-category = "main"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
-name = "six"
-version = "1.16.0"
-description = "Python 2 and 3 compatibility utilities"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -172,7 +115,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "605f627a5158153b1801269726ca9818216f892fa18077b02ec74642bb9ec971"
+content-hash = "1b018f22ba7e3332d7a81c9712a43e2bd6a862a8c299e008568d72c7fc30ceed"
 
 [metadata.files]
 assertpy = [
@@ -203,55 +146,16 @@ pluggy = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
-pypyr = [
-    {file = "pypyr-4.6.0-py3-none-any.whl", hash = "sha256:307dbc91577959764554d53ee026c38f0574643f17fd05015940d9b454fd3737"},
-    {file = "pypyr-4.6.0.tar.gz", hash = "sha256:a5930d6a5762c0d1212a458cfb3a1db561395beed12b6f4ad1037f038254a67e"},
-]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
-]
-python-dateutil = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
-]
-"ruamel.yaml" = [
-    {file = "ruamel.yaml-0.17.17-py3-none-any.whl", hash = "sha256:9af3ec5d7f8065582f3aa841305465025d0afd26c5fb54e15b964e11838fc74f"},
-    {file = "ruamel.yaml-0.17.17.tar.gz", hash = "sha256:9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be"},
-]
-"ruamel.yaml.clib" = [
-    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751"},
-    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527"},
-    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-win32.whl", hash = "sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5"},
-    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-win_amd64.whl", hash = "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"},
-    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d67f273097c368265a7b81e152e07fb90ed395df6e552b9fa858c6d2c9f42502"},
-    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:72a2b8b2ff0a627496aad76f37a652bcef400fd861721744201ef1b45199ab78"},
-    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-win32.whl", hash = "sha256:9efef4aab5353387b07f6b22ace0867032b900d8e91674b5d8ea9150db5cae94"},
-    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-win_amd64.whl", hash = "sha256:846fc8336443106fe23f9b6d6b8c14a53d38cef9a375149d61f99d78782ea468"},
-    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd"},
-    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:78988ed190206672da0f5d50c61afef8f67daa718d614377dcd5e3ed85ab4a99"},
-    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-win32.whl", hash = "sha256:a49e0161897901d1ac9c4a79984b8410f450565bbad64dbfcbf76152743a0cdb"},
-    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-win_amd64.whl", hash = "sha256:bf75d28fa071645c529b5474a550a44686821decebdd00e21127ef1fd566eabe"},
-    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a32f8d81ea0c6173ab1b3da956869114cae53ba1e9f72374032e33ba3118c233"},
-    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7f7ecb53ae6848f959db6ae93bdff1740e651809780822270eab111500842a84"},
-    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-win32.whl", hash = "sha256:89221ec6d6026f8ae859c09b9718799fea22c0e8da8b766b0b2c9a9ba2db326b"},
-    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-win_amd64.whl", hash = "sha256:31ea73e564a7b5fbbe8188ab8b334393e06d997914a4e184975348f204790277"},
-    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed"},
-    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1866cf2c284a03b9524a5cc00daca56d80057c5ce3cdc86a52020f4c720856f0"},
-    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-win32.whl", hash = "sha256:3fb9575a5acd13031c57a62cc7823e5d2ff8bc3835ba4d94b921b4e6ee664104"},
-    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-win_amd64.whl", hash = "sha256:825d5fccef6da42f3c8eccd4281af399f21c02b32d98e113dbc631ea6a6ecbc7"},
-    {file = "ruamel.yaml.clib-0.2.6.tar.gz", hash = "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd"},
-]
-six = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = ["Manuel Carmona Pérez <e.manuelvillar@go.ugr.es>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pypyr = "^4.6.0"
 pytest = "^6.2.5"
 assertpy = "^1.1"
 

--- a/tests.yaml
+++ b/tests.yaml
@@ -1,7 +1,5 @@
 # To execute this pipeline, shell something like:
 # pypyr tests
-# or, in this case,
-# poetry run pypyr tests
 steps:
   - name: pypyr.steps.cmd
     comment: Run the project tests using pytest.


### PR DESCRIPTION
Close #19 

Tras reabrir la issue #19, se hace un estudio de las distintas alternativas a la hora de elegir gestores de tareas.

Además de estudiar otras alternativas, se corrige el uso de pypyr ya que estaba siendo usado desde poetry, cosa que no es correcta.