### PR TITLE
Instala poetry desde script en Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 # Dockerfile para despliegue automático de la aplicación CineTickets. Ejecución de tests
 FROM python:3.8-alpine3.13
 
-# Instalación de deps del gestor de tareas y deps; y creación del usuario
+# Instalación de deps del gestor de tareas y deps, creación del usuario y descarga de script para instalar Poetry
 RUN apk add \
     gcc \
     libc-dev \
     libffi-dev  \
     && addgroup -S cinetickets  \
-    && adduser -S cinetickets -G cinetickets  # usuario y grupo, respectivamente
+    && adduser -S cinetickets -G cinetickets \
+    && wget https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py
 
 # Cambiar al usuario no root
 USER cinetickets
@@ -16,7 +17,8 @@ USER cinetickets
 ENV PATH=/home/cinetickets/.local/bin:$PATH
 
 # Instalación del gestor de dependencias y tareas
-RUN pip install poetry pypyr
+RUN python install-poetry.py \
+    && pip install pypyr
 
 # Cambiamos de directorio a /app/test
 WORKDIR /app/test


### PR DESCRIPTION
close #51 

En este PR, modifico la instalación de poetry para usar el script oficial, según lo detallan en su documentación. Más informacion en el comentario de la issue.